### PR TITLE
Train on large data file

### DIFF
--- a/src/fann.c
+++ b/src/fann.c
@@ -26,6 +26,7 @@
 
 #include "config.h"
 #include "fann.h"
+#include "fann_train.h"
 
 /* #define FANN_NO_SEED */
 
@@ -1177,16 +1178,8 @@ FANN_EXTERNAL void FANN_API fann_init_weights(struct fann *ann, struct fann_trai
 #endif
 	float scale_factor;
 
-	for(smallest_inp = largest_inp = train_data->input[0][0]; dat < train_data->num_data; dat++)
-	{
-		for(elem = 0; elem < train_data->num_input; elem++)
-		{
-			if(train_data->input[dat][elem] < smallest_inp)
-				smallest_inp = train_data->input[dat][elem];
-			if(train_data->input[dat][elem] > largest_inp)
-				largest_inp = train_data->input[dat][elem];
-		}
-	}
+    smallest_inp = fann_get_min_train_input(train_data);
+    largest_inp = fann_get_max_train_input(train_data);
 
 	num_hidden_neurons = (unsigned int)(
 		ann->total_neurons - (ann->num_input + ann->num_output +

--- a/src/fann_train.c
+++ b/src/fann_train.c
@@ -536,6 +536,16 @@ void fann_update_slopes_batch(struct fann *ann, struct fann_layer *layer_begin,
 }
 
 /* INTERNAL FUNCTION
+ */
+void fann_default_train_strategy(struct fann *ann, fann_type *input, fann_type *output)
+{
+    fann_run(ann, input);
+    fann_compute_MSE(ann, output);
+    fann_backpropagate_MSE(ann);
+    fann_update_slopes_batch(ann, ann->first_layer + 1, ann->last_layer - 1);
+}
+
+/* INTERNAL FUNCTION
    Clears arrays used for training before a new training session.
    Also creates the arrays that do not exist yet.
  */

--- a/src/include/fann_internal.h
+++ b/src/include/fann_internal.h
@@ -124,6 +124,8 @@ int fann_allocate_scale(struct fann *ann);
 FANN_EXTERNAL void FANN_API fann_scale_data_to_range(fann_type ** data, unsigned int num_data, unsigned int num_elem,
 					 fann_type old_min, fann_type old_max, fann_type new_min, fann_type new_max);
 
+struct fann_train_data *fann_merge_in_file_data(struct fann_train_data *data1, struct fann_train_data *data2);
+
 /* called fann_max, in order to not interferre with predefined versions of max */
 #define fann_max(x, y) (((x) > (y)) ? (x) : (y))
 #define fann_min(x, y) (((x) < (y)) ? (x) : (y))

--- a/src/include/fann_internal.h
+++ b/src/include/fann_internal.h
@@ -84,6 +84,9 @@ void fann_backpropagate_MSE(struct fann *ann);
 void fann_update_weights(struct fann *ann);
 void fann_update_slopes_batch(struct fann *ann, struct fann_layer *layer_begin,
 							  struct fann_layer *layer_end);
+void fann_default_train_strategy(struct fann *ann, fann_type *input, fann_type *output);
+void fann_apply_strategy_to_data(struct fann *ann, struct fann_train_data *data,
+                                void (*strategy)( struct fann *, fann_type *, fann_type *));
 void fann_update_weights_quickprop(struct fann *ann, unsigned int num_data,
 								   unsigned int first_weight, unsigned int past_end);
 void fann_update_weights_batch(struct fann *ann, unsigned int num_data, unsigned int first_weight,

--- a/src/include/fann_internal.h
+++ b/src/include/fann_internal.h
@@ -126,6 +126,8 @@ FANN_EXTERNAL void FANN_API fann_scale_data_to_range(fann_type ** data, unsigned
 
 struct fann_train_data *fann_merge_in_file_data(struct fann_train_data *data1, struct fann_train_data *data2);
 
+struct fann_train_data *fann_duplicate_in_file_data(struct fann_train_data *data);
+
 /* called fann_max, in order to not interferre with predefined versions of max */
 #define fann_max(x, y) (((x) > (y)) ? (x) : (y))
 #define fann_min(x, y) (((x) < (y)) ? (x) : (y))

--- a/src/include/fann_train.h
+++ b/src/include/fann_train.h
@@ -403,7 +403,6 @@ FANN_EXTERNAL fann_type * FANN_API fann_get_train_output(struct fann_train_data 
  */ 
 FANN_EXTERNAL void FANN_API fann_shuffle_train_data(struct fann_train_data *train_data);
 
-#ifndef FIXEDFANN
 
 /* Function: fann_get_min_train_input
 
@@ -437,6 +436,7 @@ FANN_EXTERNAL fann_type FANN_API fann_get_min_train_output(struct fann_train_dat
 */
 FANN_EXTERNAL fann_type FANN_API fann_get_max_train_output(struct fann_train_data *train_data);
 
+#ifndef FIXEDFANN
 
 /* Function: fann_scale_train
 

--- a/src/include/fann_train.h
+++ b/src/include/fann_train.h
@@ -38,6 +38,20 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  			is supported by <FANN Cascade Training>.
  */
 
+/* Enums: fann_in_file_data_format_enum
+
+   fann_train_data can train on in-file data directly, without loading it to memory. This is useful especially for large size training data. In-file data can be trained, merged, duplicated, but cannot be scaled, shuffled yet.
+
+   FANN_TEXT_FORMAT_IN_FILE_DATA - The same format as fann/datasets/[*].train files
+   FANN_BINARY_FORMAT_IN_FILE_DATA - Serialized data, with the same structure as text format. Serialized data can be read/written much faster.
+
+ */
+enum fann_in_file_data_format_enum
+{
+    FANN_TEXT_FORMAT_IN_FILE_DATA,
+    FANN_BINARY_FORMAT_IN_FILE_DATA
+};
+
 /* Struct: struct fann_train_data
 	Structure used to store data, for use with training.
 	
@@ -61,6 +75,10 @@ struct fann_train_data
 	unsigned int num_output;
 	fann_type **input;
 	fann_type **output;
+
+    char **file;
+    enum fann_in_file_data_format_enum *file_format;
+    unsigned int num_file;
 };
 
 /* Section: FANN Training */
@@ -334,6 +352,19 @@ FANN_EXTERNAL struct fann_train_data * FANN_API fann_create_train_from_callback(
                                                                  fann_type * ,
                                                                  fann_type * ));
 
+/* Function: fann_create_train_from_in_file_data
+   Creates the training data struct from a file, without loading it to memory.
+   
+   Parameters:
+     configuration_file     - training data file name
+     format                 - format of the training data file
+
+   See also:
+     <fann_in_file_data_format_enum>
+
+    This function appears in FANN > 2.2
+*/
+FANN_EXTERNAL struct fann_train_data *fann_create_train_from_in_file_data(const char *configuration_file, enum fann_in_file_data_format_enum format);
 /* Function: fann_destroy_train
    Destructs the training data and properly deallocates all of the associated data.
    Be sure to call this function when finished using the training data.


### PR DESCRIPTION
Interfaces are not changed; I just add `fann_create_train_from_in_file_data` function.
However, if you create `struct fann_train_data` using `fann_create_train_from_in_file_data`, most data-handling functions (e.g. shuffle, scale, ...) will not work on that instance. (undefined behavior!) Only merge, duplicate and min_max functions are implemented for that instance.

```c
// Usage (example)
unsigned int num_neurons_in_layer[3] = {100, 100, 3};
struct fann *ann = fann_create_standard_array(3, num_neurons_in_layer);
struct fann_train_data *data = fann_create_train_from_in_file_data("mydata.train", FANN_TEXT_FORMAT_IN_FILE_DATA);
fann_train_on_data(ann, data, 100, 1, 0.01);
fann_save(ann, "mymodel.fann");
```